### PR TITLE
Make pandas an optional dependency

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,11 +5,11 @@ Installation:
 
 The latest stable can be installed using easy_install or pip::
 
-    sudo pip install link
+    pip install link
 
 or::
 
-    sudo easy_install link
+    easy_install link
 
 You can also clone and install it::
 
@@ -33,7 +33,9 @@ installed.  Here is a list of packages that may be used.::
     pyscopg ==> PostgresDB
     pyhive ==> PrestoDB
 
-You should be able to pip or easy_install any of these packages very easily
+You should be able to pip or easy_install any of these packages very easily.
 
+Additional functionality is enabled when the ``pandas`` package is installed.
+To install it along with ``link``, specify it as an optional dependency::
 
-
+    pip install link[pandas]

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -135,9 +135,8 @@ Database connections work the same way::
 Queries to Pandas Dataframes
 -----------------------------
 
-If you don't know about pandas you are missing out (make sure its installed).  
-You can select any query into Pandas DataFrames using the select function
-instead of the select function of a DBConnectionWrapper::
+``pandas`` users: you can select any query into Pandas DataFrames using the
+select function instead of the select function of a DBConnectionWrapper::
 
     In [35]: my_db = lnk.dbs.my_db
 
@@ -155,6 +154,7 @@ instead of the select function of a DBConnectionWrapper::
     dtypes: float64(2), int64(3), object(4)
 
 pandas allows you to do groupbys, sums, aggregations, joins...and much more in
-memory.  For more information see the pandas homepage (TODO put link in here)
+memory.  For more information see the
+`pandas homepage <https://pandas.pydata.org/>`__.
 
 

--- a/link/s3_writer.py
+++ b/link/s3_writer.py
@@ -21,14 +21,12 @@ from gzip import GzipFile
 from io import SEEK_SET
 
 try:
-    from pandas import DataFrame, Series
-except:
-    pass
-
-try:
     import ujson as json
 except ImportError:
     import json
+
+
+from link.utils import pd
 
 
 class S3Writer(object):
@@ -73,7 +71,7 @@ class S3Writer(object):
             else:
                 io.write(str.encode(json.dumps(data)))
 
-        elif isinstance(data, DataFrame) or isinstance(data, Series):
+        elif (pd is not None) and (isinstance(data, pd.DataFrame) or isinstance(data, pd.Series)):
             if six.PY2:
                 data.to_csv(io, index=False, header=df_column_names)
             else:

--- a/link/utils.py
+++ b/link/utils.py
@@ -9,6 +9,13 @@ if six.PY3:
     izip = zip
 else:
     from itertools import izip
+
+# pandas is an optional dependency
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
 # -*- coding: utf-8 -*-
 
 """
@@ -47,17 +54,10 @@ def list_to_dataframe(rows, names):
     :params rows: the data you want to put in the dataframe
     :params names: the column names for the dataframe
     """
-    from pandas import DataFrame
-    col_convert_func = None
-    try:
-        import pandas._tseries as lib
-        col_convert_func = lib.convert_sql_column
-    except ImportError:
-        import pandas.lib as lib
-        try:
-            col_convert_func = lib.convert_sql_column
-        except:
-            col_convert_func = partial(lib.maybe_convert_objects, try_float=1)
+    if pd is None:
+        raise RuntimeError('pandas is required to use dataframes')
+
+    col_convert_func = partial(pd._libs.lib.maybe_convert_objects, try_float=1)
 
     if isinstance(rows, tuple):
         rows = list(rows)
@@ -68,7 +68,7 @@ def list_to_dataframe(rows, names):
         for k, v in columns.iteritems():
             columns[k] = col_convert_func(v)
 
-    return DataFrame(columns, columns=names)
+    return pd.DataFrame(columns, columns=names)
 
 
 
@@ -78,3 +78,5 @@ def array_pagenate(n, iterable, padvalue=None):
     pad the end with your default value to make fully even.  
     """
     return izip(*[chain(iterable, repeat(padvalue, n-1))]*n)
+
+

--- a/link/wrappers/cassandrawrapper.py
+++ b/link/wrappers/cassandrawrapper.py
@@ -2,6 +2,7 @@ import time
 
 from link import Wrapper
 from link.exceptions import LNKAttributeException
+from link.utils import pd
 
 
 class CassandraResultsetWrapper(Wrapper):
@@ -21,14 +22,16 @@ class CassandraResultsetWrapper(Wrapper):
     def as_dataframe(self):
         """Convert query result rows to pandas dataframe.
         """
-        from pandas import DataFrame
+        if pd is None:
+            raise RuntimeError('pandas is required to use dataframes')
+
         from cassandra import DriverException
-        df = DataFrame()
+        df = pd.DataFrame()
         data = self.result
         while True:
             for retry in range(self.max_retries):
                 try:
-                    df = df.append(DataFrame(columns=data.column_names, data=(list(row) for row in data.current_rows)))
+                    df = df.append(pd.DataFrame(columns=data.column_names, data=(list(row) for row in data.current_rows)))
                     break
                 except DriverException:
                     if retry >= self.max_retries - 1:

--- a/link/wrappers/dbwrappers.py
+++ b/link/wrappers/dbwrappers.py
@@ -133,13 +133,10 @@ class DBConnectionWrapper(Wrapper):
         Select everything into a datafrome with the column names
         being the names of the colums in the dataframe
         """
-        try:
-            import pandas 
-        except:
-            raise Exception("pandas required to select dataframe. Please install"  +
-                            "sudo easy_install pandas")
+        if pd is None:
+            raise RuntimeError('pandas is required to use dataframes')
         
-        data = pandas.read_sql(query, self._wrapped, params = args)
+        data = pd.read_sql(query, self._wrapped, params = args)
         data.rename({x: x.lower() for x in data.columns}, axis=1, inplace=True)
         return data
 

--- a/link/wrappers/prestowrapper.py
+++ b/link/wrappers/prestowrapper.py
@@ -1,4 +1,5 @@
 from link import Wrapper
+from link.utils import pd
 
 
 class PrestoDB(Wrapper):
@@ -24,10 +25,8 @@ class PrestoDB(Wrapper):
         Select everything into a dataframe with the column names
         being the names of the columns in the dataframe
         """
-        try:
-            import pandas as pd
-        except:
-            raise Exception("pandas required to select dataframe.")
+        if pd is None:
+            raise RuntimeError('pandas is required to use dataframes')
 
         df = pd.read_sql(query, self.engine)
         return df

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ SETUP_ARGS = {}
 DATA_FILES = [('link/configs', ['link/configs/link.config'])]
 REQUIRES = ['requests>=2.0.0', 'requests_oauthlib>=0.4.0', 'xmltodict' , 'six']
 EXTRAS_REQUIRE = {
-      'pandas': ['pandas'],
+      'pandas': ['pandas>=1.0.0'],
 }
 
 # write out the version file so we can keep track on what version the built

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 dir = os.path.split(os.path.abspath(__file__))[0]
 
 #import all of this version information
-__version__ = '2.0.4'
+__version__ = '2.1.0'
 __author__ = 'David Buonasera'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2019 David Buonasera'

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ CLASSIFIERS = ['Development Status :: 4 - Beta',
 EMAIL = ''
 SETUP_ARGS = {}
 DATA_FILES = [('link/configs', ['link/configs/link.config'])]
-REQUIRES = ['requests>=2.0.0', 'requests_oauthlib>=0.4.0', 'pandas', 'xmltodict' , 'six']
+REQUIRES = ['requests>=2.0.0', 'requests_oauthlib>=0.4.0', 'xmltodict' , 'six']
+EXTRAS_REQUIRE = {
+      'pandas': ['pandas'],
+}
 
 # write out the version file so we can keep track on what version the built
 # package is
@@ -39,6 +42,7 @@ setup(name=__title__,
       maintainer=__author__,
       url=URL,
       packages=['link', 'link.wrappers', 'link.configs'],
+      extras_require=EXTRAS_REQUIRE,
       #package_data = {'link.configs': ['link.configs/*config']},
       install_requires=REQUIRES,
       #data_files = DATA_FILES,


### PR DESCRIPTION
I was happy to see https://github.com/9thbitio/link/pull/33 make this library function without `pandas`. Not having to have that library installed allows for applications that don't use `DataFrame`s to be smaller (and run on, e.g. AWS Lambda).

I noticed that using `pip install link` or `python setup.py` for this project still brings in `pandas` - it is still part of the `install_requires` list. This is unfortunate for me, as it means I must manually uninstall that library in each application that uses `link`.

This PR makes `pandas` an [optional dependency](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies). This allows a user to do `pip install link` for a minimal installation and `pip install link[pandas]` for an augmented installation.

I've also updated the parts of the package that `import` something from `pandas` to use a consistent interface.

If these changes are welcome, I will submit an analogous PR for the `springserve` package, which also has `pandas` in its `install_requires` list. 